### PR TITLE
Fixed margin-left in RedmineUP Circle theme 

### DIFF
--- a/assets/stylesheets/editor.css
+++ b/assets/stylesheets/editor.css
@@ -17,6 +17,11 @@
  *
  */
 
+.theme-Circle > #wrapper > #wrapper2 > #wrapper3 > #main > #content {
+    margin-left: -20px !important;
+    padding: 0;
+}
+
 #content {
     padding: 0;
 }


### PR DESCRIPTION
Fixed margin-left space in RedmineUP Circle theme.

<img width="409" alt="redmine_margin_left_circle" src="https://user-images.githubusercontent.com/499411/159791108-364931bd-d2cd-4e40-b823-3e568c89e4da.png">
