### PR TITLE
fix: manually check versions of dependencies #153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ##
 ## Features
-- Filling pdf instead of pdf
+- Filling pdf instead of oform
+
+## Bug Fixes
+- Manually check versions of dependencies
 
 ## 3.0.1
 ## Bug Fixes

--- a/Gemfile.prod
+++ b/Gemfile.prod
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jwt", "~> 2.7.1"
-gem "mustache", "~> 1.1.1"
-gem "render_parent", "~> 0.1.0"
-gem "sorbet-runtime", "~> 0.5.10969"
+gem "jwt"
+gem "mustache"
+gem "render_parent"
+gem "sorbet-runtime"

--- a/init.rb
+++ b/init.rb
@@ -19,6 +19,7 @@
 # frozen_string_literal: true
 
 require "redmine"
+require "rubygems"
 require_relative "lib2/onlyoffice"
 require_relative "lib2/only_office"
 require_relative "app/views/views"
@@ -41,6 +42,20 @@ OnlyOffice.logger = logger
 logger = Rails.logger.dup
 logger.progname = OnlyOfficeRedmine.logger.progname.dup
 OnlyOfficeRedmine.logger = logger
+
+def check_gem(name, version)
+  Gem::Specification.find_by_name(name, version)
+rescue Gem::MissingSpecVersionError
+  spec = Gem::Specification.find_by_name(name)
+  OnlyOfficeRedmine.logger.error("Gem '#{name}' version '#{version}' not found, found version '#{spec.version}'")
+rescue Gem::MissingSpecError
+  OnlyOfficeRedmine.logger.error("Gem '#{name}' version '#{version}' not found")
+end
+
+check_gem("jwt", "~> 2.7.1")
+check_gem("mustache", "~> 1.1.1")
+check_gem("render_parent", "~> 0.1.0")
+check_gem("sorbet-runtime", "~> 0.5.10969")
 
 Redmine::Plugin.register(OnlyOfficeRedmine::NAME.to_sym) do
   # rubocop:disable Layout/LineLength


### PR DESCRIPTION
The issue is that all Redmine plugins are essentially combined into a single monolith. When installing dependencies, Bundler does not just consider a specific Gemfile, but everything in the monolith, including Redmine's Gemfile. This can lead to conflicts if the same Gem is present in both our Gemfile and someone else's. Unfortunately, we do not have many options other than omitting version specifications for our dependencies. To make this less disheartening, we can manually check if the required versions are available. If they are missing, we can notify the user and hope that our plugin will still work with their installed dependencies.
